### PR TITLE
Fix implode order of parameters

### DIFF
--- a/src/ControlSequences/Base.php
+++ b/src/ControlSequences/Base.php
@@ -68,12 +68,12 @@ class Base
 
         // Append Parameter Byte (if any)
         if (isset($this->parameterBytes) && sizeof((array) $this->parameterBytes) > 0) {
-            $toReturn .= implode($this->parameterBytes, ';');
+            $toReturn .= implode(';', $this->parameterBytes);
         }
 
         // Append Intermediate Bytes (if any)
         if (isset($this->intermediateBytes) && sizeof((array) $this->intermediateBytes) > 0) {
-            $toReturn .= implode($this->intermediateBytes, ';'); // @TODO: Verify that ';' is the glue for intermediate bytes
+            $toReturn .= implode(';', $this->intermediateBytes); // @TODO: Verify that ';' is the glue for intermediate bytes
         }
 
         // Append Final Byte (if any)


### PR DESCRIPTION
PHP 7.4 enforces the order of parameters for implode, it now throws an error