### PR TITLE
Fix PHPDoc references.

### DIFF
--- a/src/Ansi.php
+++ b/src/Ansi.php
@@ -17,13 +17,13 @@ class Ansi
 
     /**
      * The writer to write the data to
-     * @var Writer\WriterInterface
+     * @var Writers\WriterInterface
      */
     protected $writer;
 
     /**
      * ANSI Wrapper Class to work with \Bramus\Ansi more easily
-     * @param Writer\WriterInterface $writer writer to use
+     * @param Writers\WriterInterface $writer writer to use
      */
     public function __construct($writer = null)
     {
@@ -38,7 +38,7 @@ class Ansi
 
     /**
      * Sets the writer
-     * @param Writer\WriterInterface $writer The writer to use
+     * @param Writers\WriterInterface $writer The writer to use
      */
     public function setWriter(Writers\WriterInterface $writer)
     {
@@ -47,7 +47,7 @@ class Ansi
 
     /**
      * Gets the writer
-     * @return Writer\WriterInterface $writer The writer used
+     * @return Writers\WriterInterface $writer The writer used
      */
     public function getWriter()
     {

--- a/src/Traits/EscapeSequences/ED.php
+++ b/src/Traits/EscapeSequences/ED.php
@@ -3,6 +3,7 @@
 namespace Bramus\Ansi\Traits\EscapeSequences;
 
 use Bramus\Ansi\ControlSequences\EscapeSequences\Enums\ED as EnumED;
+use Bramus\Ansi\Ansi;
 
 /**
  * Trait containing the ED Escape Function Shorthands

--- a/src/Traits/EscapeSequences/EL.php
+++ b/src/Traits/EscapeSequences/EL.php
@@ -3,6 +3,7 @@
 namespace Bramus\Ansi\Traits\EscapeSequences;
 
 use Bramus\Ansi\ControlSequences\EscapeSequences\Enums\EL as EnumEL;
+use Bramus\Ansi\Ansi;
 
 /**
  * Trait containing the EL Escape Function Shorthands

--- a/src/Traits/EscapeSequences/SGR.php
+++ b/src/Traits/EscapeSequences/SGR.php
@@ -3,6 +3,7 @@
 namespace Bramus\Ansi\Traits\EscapeSequences;
 
 use Bramus\Ansi\ControlSequences\EscapeSequences\Enums\SGR as EnumSGR;
+use Bramus\Ansi\Ansi;
 
 /**
  * Trait containing the SGR Escape Function Shorthands


### PR DESCRIPTION
Hello, here is a patch to fix some simple errors in PHP docblocks that lead to problems with PHPStan and IDE autocompletion.

Given the following code:

```
use Bramus\Ansi\Ansi;
use Bramus\Ansi\Writers\BufferWriter;
use Bramus\Ansi\ControlSequences\EscapeSequences\Enums\SGR;

$ansi = new Ansi(new BufferWriter());
$ansi->color([SGR::COLOR_FG_WHITE])->get();
```

Running PHPStan on this code will yield the following errors:

```
1) Parameter #1 $writer of class Bramus\Ansi\Ansi constructor expects
    Bramus\Ansi\Writer\WriterInterface|null,
    Bramus\Ansi\Writers\BufferWriter given.

2) Call to method get() on an unknown class Bramus\Ansi\Traits\EscapeSequences\Ansi.
```

The first issue is just a typo, `Writer` versus `Writers` in a number of docblock attributes in `Ansi.php`.

The second issue is a result of the traits using `@return Ansi` but Ansi is not in the same namespace as the trait. This was fixed simply by adding the appropriate `use` statement.

All tests passing, no functionality added or changed.