### PR TITLE
[fix] PhpStorm error: Return value is expected to be '\Bramus\Ansi\Ansi', '\Bramus\Ansi\Traits\Ansi' returned

### DIFF
--- a/src/Traits/ControlFunctions.php
+++ b/src/Traits/ControlFunctions.php
@@ -2,6 +2,8 @@
 
 namespace Bramus\Ansi\Traits;
 
+use Bramus\Ansi\Ansi;
+
 /**
  * Trait containing the Control Function Shorthands
  */


### PR DESCRIPTION
Hi, thanks for the great library.

PhpStorm couldn't resolve the return type for methods in `Bramus\Ansi\Traits\ControlFunctions` so I made a small fix.

Example code that shows the error:

```
    public function line(string $text): \Bramus\Ansi\Ansi
    {
        return $this->text($text)->lf();
    }
```

This should also fix https://github.com/bramus/ansi-php/issues/10.