### PR TITLE
Shortcode parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+.idea/

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,8 @@ When it comes to ANSI Escape Sequences `bramus/ansi-php` supports:
 - CUF _(Cursor Forward)_: Move cursor forward.
 - CUP _(Cursor Position)_: Move cursor to position.
 - CUU _(Cursor Up)_: Move cursor up.
+- DECSC _(Save Cursor Position)_: The DEC/VT100 method of saving a saved cursor position (and attributes, like color).
+- DECRC _(Restore Cursor Position)_: The DEC/VT100 method of restoring a saved cursor position (and attributes).
 - ED _(Erase Display)_: Erase (parts of) the display.
 - EL _(Erase In Line)_: Erase (parts of) the current line.
 - SGR _(Select Graphic Rendition)_: Manipulate text styling (bold, underline, blink, colors, etc.).
@@ -146,13 +148,15 @@ These shorthands write EL ANSI Escape Sequences to the writer.
 - `eraseLineToEOL()`: Erase from the current cursor position to the end of the current line.
 - `eraseLineToSOL()`: Erases from the current cursor position to the start of the current line.
 
-### CUB/CUD/CUF/CUP/CUU ANSI Escape Sequence shorthands:
+### CUB/CUD/CUF/CUP/CUU/DECSC/DECRC ANSI Escape Sequence shorthands:
 
 - `cursorBack($n)`: Move cursor back `$n` positions _(default: 1)_
 - `cursorForward($n)`: Move cursor forward `$n` positions _(default: 1)_
 - `cursorDown($n)`: Move cursor down `$n` positions _(default: 1)_
 - `cursorUp($n)`: Move cursor up `$n` positions _(default: 1)_
 - `cursorPosition($n, $m)`: Move cursor to position `$n,$m` _(default: 1,1)_
+- `saveCursorPosition()`: Saves current position (and attributes) of the cursor
+- `restoreCursorPosition()`: Restores the saved cursor position (and attributes)
 
 ### Extra functions
 

--- a/src/Ansi.php
+++ b/src/Ansi.php
@@ -18,6 +18,8 @@ class Ansi
     use Traits\EscapeSequences\CUF;
     use Traits\EscapeSequences\CUP;
     use Traits\EscapeSequences\CUU;
+    use Traits\EscapeSequences\DECSC;
+    use Traits\EscapeSequences\DECRC;
     use Traits\EscapeSequences\SGR;
 
     /**

--- a/src/ControlSequences/EscapeSequences/DECRC.php
+++ b/src/ControlSequences/EscapeSequences/DECRC.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * DECRC - RESTORE CURSOR POSITION
+ * 
+ */
+namespace Bramus\Ansi\ControlSequences\EscapeSequences;
+
+class DECRC extends Base
+{
+    /**
+     * DECRC - Restore Cursor Position (the DEC/VT100 way)
+     */
+    public function __construct()
+    {
+        // Call Parent Constructor (which will store finalByte)
+        parent::__construct(
+            \Bramus\Ansi\ControlSequences\EscapeSequences\Enums\FinalByte::DECRC
+        );
+    }
+}

--- a/src/ControlSequences/EscapeSequences/DECSC.php
+++ b/src/ControlSequences/EscapeSequences/DECSC.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * DECSC - The DEC way to save cursor position
+ * 
+ */
+namespace Bramus\Ansi\ControlSequences\EscapeSequences;
+
+class DECSC extends Base
+{
+    /**
+     * DECSC - Save Cursor Position (the DEC/VT100 way)
+     */
+    public function __construct()
+    {
+        // Call Parent Constructor (which will store finalByte)
+        parent::__construct(
+            \Bramus\Ansi\ControlSequences\EscapeSequences\Enums\FinalByte::DECSC
+        );
+    }
+}

--- a/src/ControlSequences/EscapeSequences/Enums/FinalByte.php
+++ b/src/ControlSequences/EscapeSequences/Enums/FinalByte.php
@@ -6,6 +6,25 @@ namespace Bramus\Ansi\ControlSequences\EscapeSequences\Enums;
 
 class FinalByte
 {
+    /**
+     * DECSC - SAVE CURSOR POSITION & ATTRIBUTES
+     *
+     * Calls the DEC/VT100 standard to save cursor position (and attributes)
+     * for later recall using DECRC.
+     *
+     * @type string
+     */
+    const DECSC = '7';
+
+    /**
+     * DECRC - RESTORE CURSOR POSITION & ATTRIBUTES
+     *
+     * Calls the DEC/VT100 standard to restore cursor position (and attributes)
+     * set by DECSC.
+     *
+     * @type string
+     */
+    const DECRC = '8';
 
     /**
      * CUB - CURSOR BACK

--- a/src/Traits/EscapeSequences/DECRC.php
+++ b/src/Traits/EscapeSequences/DECRC.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Bramus\Ansi\Traits\EscapeSequences;
+
+/**
+ * Trait containing the DECRC (Restore Cursor Position) Escape Function Shorthands
+ * This is the DEC (VT100) code to restore a saved cursor position
+ */
+trait DECRC
+{
+    /**
+     * Save cursor position
+     * @return Ansi  self, for chaining
+     */
+    public function decrc()
+    {
+        // Write data to the writer
+        $this->writer->write(
+            new \Bramus\Ansi\ControlSequences\EscapeSequences\DECRC()
+        );
+
+        // Afford chaining
+        return $this;
+    }
+
+    /**
+     * More readable alias for DECRC
+     * @return Ansi    self, for chaining
+     */
+    public function restoreCursorPosition()
+    {
+        return $this->decrc();
+    }
+}

--- a/src/Traits/EscapeSequences/DECSC.php
+++ b/src/Traits/EscapeSequences/DECSC.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Bramus\Ansi\Traits\EscapeSequences;
+
+/**
+ * Trait containing the DECSC (Save Cursor Position) Escape Function Shorthands
+ * This is the DEC (VT100) code to save current cursor position
+ */
+trait DECSC
+{
+    /**
+     * Save cursor position
+     * @return Ansi  self, for chaining
+     */
+    public function decsc()
+    {
+        // Write data to the writer
+        $this->writer->write(
+            new \Bramus\Ansi\ControlSequences\EscapeSequences\DECSC()
+        );
+
+        // Afford chaining
+        return $this;
+    }
+
+    /**
+     * More readable alias for DECSC
+     * @return Ansi    self, for chaining
+     */
+    public function saveCursorPosition()
+    {
+        return $this->decsc();
+    }
+}

--- a/tests/EscapeSequenceDECRCTest.php
+++ b/tests/EscapeSequenceDECRCTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use Bramus\Ansi\Ansi;
+use Bramus\Ansi\Writers\StreamWriter;
+use Bramus\Ansi\ControlFunctions\Enums\C0;
+use Bramus\Ansi\ControlSequences\EscapeSequences\DECRC as EscapeSequenceDECRC;
+use Bramus\Ansi\ControlSequences\EscapeSequences\Enums\FinalByte;
+
+class EscapeSequenceDECRCTest extends PHPUnit_Framework_TestCase
+{
+    public function testInstantiation()
+    {
+        $es = new EscapeSequenceDECRC();
+
+        $this->assertInstanceOf('\Bramus\Ansi\ControlSequences\EscapeSequences\DECRC', $es);
+
+        // Final byte must be DECRC
+        $this->assertEquals(
+            $es->getFinalByte(),
+            FinalByte::DECRC
+        );
+    }
+
+    public function testDECRCRaw()
+    {
+        $this->assertEquals(
+            new EscapeSequenceDECRC(),
+            C0::ESC . '[' . FinalByte::DECRC
+        );
+    }
+
+    public function testAnsiDECRCShorthandsSingle()
+    {
+        $a = new Ansi(new \Bramus\Ansi\Writers\BufferWriter());
+
+        $this->assertEquals(
+            $a->restoreCursorPosition()->get(),
+            new EscapeSequenceDECRC()
+        );
+    }
+
+    public function testAnsiDECRCShorthandChained()
+    {
+        $a = new Ansi(new \Bramus\Ansi\Writers\BufferWriter());
+        $es = new EscapeSequenceDECRC();
+
+        $this->assertEquals(
+            $a->restoreCursorPosition()->text('test')->get(),
+            $es . 'test'
+        );
+    }
+
+    public function testAnsiDECRCShorthandsChained()
+    {
+        $a = new Ansi(new \Bramus\Ansi\Writers\BufferWriter());
+
+        $this->assertEquals(
+            $a->restoreCursorPosition()->text('test')->restoreCursorPosition()->get(),
+            (new EscapeSequenceDECRC()) . 'test' . (new EscapeSequenceDECRC())
+        );
+    }
+
+    public function testAnsiDECRCPractical()
+    {
+        $this->markTestIncomplete("I was unable to make a working practical test of this");
+    }
+}
+
+// EOF

--- a/tests/EscapeSequenceDECSCTest.php
+++ b/tests/EscapeSequenceDECSCTest.php
@@ -1,14 +1,13 @@
 <?php
 
-use \Bramus\Ansi\Ansi;
-use \Bramus\Ansi\Writers\StreamWriter;
-use \Bramus\Ansi\ControlFunctions\Enums\C0;
-use \Bramus\Ansi\ControlSequences\EscapeSequences\DECSC as EscapeSequenceDECSC;
-use \Bramus\Ansi\ControlSequences\EscapeSequences\Enums\FinalByte;
+use Bramus\Ansi\Ansi;
+use Bramus\Ansi\Writers\StreamWriter;
+use Bramus\Ansi\ControlFunctions\Enums\C0;
+use Bramus\Ansi\ControlSequences\EscapeSequences\DECSC as EscapeSequenceDECSC;
+use Bramus\Ansi\ControlSequences\EscapeSequences\Enums\FinalByte;
 
 class EscapeSequenceDECSCTest extends PHPUnit_Framework_TestCase
 {
-
     public function testInstantiation()
     {
         $es = new EscapeSequenceDECSC();
@@ -26,7 +25,7 @@ class EscapeSequenceDECSCTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals(
             new EscapeSequenceDECSC(),
-            C0::ESC.'['.FinalByte::DECSC
+            C0::ESC . '[' . FinalByte::DECSC
         );
     }
 
@@ -47,24 +46,23 @@ class EscapeSequenceDECSCTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $a->saveCursorPosition()->text('test')->get(),
-            $es.'test'
+            $es . 'test'
         );
     }
 
     public function testAnsiDECSCShorthandsChained()
     {
-
         $a = new Ansi(new \Bramus\Ansi\Writers\BufferWriter());
 
         $this->assertEquals(
             $a->saveCursorPosition()->text('test')->saveCursorPosition()->get(),
-            (new EscapeSequenceDECSC()).'test'.(new EscapeSequenceDECSC())
+            (new EscapeSequenceDECSC()) . 'test' . (new EscapeSequenceDECSC())
         );
     }
 
     public function testAnsiDECSCPractical()
     {
-        $this->fail("I was unable to make a working practical test of this, and could not figure out why. If you can I'd be grateful :)");
+        $this->markTestIncomplete("I was unable to make a working practical test of this, and could not figure out why. If you can I'd be grateful :)");
     }
 }
 

--- a/tests/EscapeSequenceDECSCTest.php
+++ b/tests/EscapeSequenceDECSCTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use \Bramus\Ansi\Ansi;
+use \Bramus\Ansi\Writers\StreamWriter;
+use \Bramus\Ansi\ControlFunctions\Enums\C0;
+use \Bramus\Ansi\ControlSequences\EscapeSequences\DECSC as EscapeSequenceDECSC;
+use \Bramus\Ansi\ControlSequences\EscapeSequences\Enums\FinalByte;
+
+class EscapeSequenceDECSCTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testInstantiation()
+    {
+        $es = new EscapeSequenceDECSC();
+
+        $this->assertInstanceOf('\Bramus\Ansi\ControlSequences\EscapeSequences\DECSC', $es);
+
+        // Final byte must be DECSC
+        $this->assertEquals(
+            $es->getFinalByte(),
+            FinalByte::DECSC
+        );
+    }
+
+    public function testDECSCRaw()
+    {
+        $this->assertEquals(
+            new EscapeSequenceDECSC(),
+            C0::ESC.'['.FinalByte::DECSC
+        );
+    }
+
+    public function testAnsiDECSCShorthandsSingle()
+    {
+        $a = new Ansi(new \Bramus\Ansi\Writers\BufferWriter());
+
+        $this->assertEquals(
+            $a->saveCursorPosition()->get(),
+            new EscapeSequenceDECSC()
+        );
+    }
+
+    public function testAnsiDECSCShorthandChained()
+    {
+        $a = new Ansi(new \Bramus\Ansi\Writers\BufferWriter());
+        $es = new EscapeSequenceDECSC();
+
+        $this->assertEquals(
+            $a->saveCursorPosition()->text('test')->get(),
+            $es.'test'
+        );
+    }
+
+    public function testAnsiDECSCShorthandsChained()
+    {
+
+        $a = new Ansi(new \Bramus\Ansi\Writers\BufferWriter());
+
+        $this->assertEquals(
+            $a->saveCursorPosition()->text('test')->saveCursorPosition()->get(),
+            (new EscapeSequenceDECSC()).'test'.(new EscapeSequenceDECSC())
+        );
+    }
+
+    public function testAnsiDECSCPractical()
+    {
+        $this->fail("I was unable to make a working practical test of this, and could not figure out why. If you can I'd be grateful :)");
+    }
+}
+
+// EOF


### PR DESCRIPTION
# Shortcode parser
Just a simple QOL update that allows you to put small shortcodes in a string and parse it into ANSI. It turns something like this:
```php
$writer->eraseDisplay()->cursorPosition(12,22)->underline()->text("Hello")->reset()->cursorDown(2)->color(SGR::COLOR_FG_GREEN)->text("wo")->bold()->text("rl")->normal()->text("d!")->reset()->lf()->lf()->lf();
```

into:
```php
$str = "%c%%xy12,22%%u%Hello%r%%cd2% %f2%wo%b%rl%n%d!%r%%lf%%lf%%lf%";
$parser->parse($str);
```

Works with both StreamWriter and BufferWriter. If using Proxy or Buffer you need to flush/echo manually as per usual.

## Supported shortcodes
|  shortcode | Equivalent |
|---|---|
| __`%b%`__ | `bold()` |
| __`%n%`__ | `normal()` |
| __`%f%`__ | `faint()` |
| __`%i%`__ | `italic()` |
| __`%u%`__ | `underline()` |
| __`%bl%`__ | `blink()` |
| __`%n%`__ | `negative()` |
| __`%s%`__ | `strikethrough()` |
| __`%r%`__ | `nostyle()` |
| __`%f<num>%`__ | `color(SGR::COLOR_FG_*)` |
| __`%b<num>%`__ | `color(SGR::COLOR_BG_*)` |
| __`%c%`__ | `eraseDisplay()` |
| __`%eu%`__ | `eraseDisplayUp()` |
| __`%ed%`__ | `eraseDisplayDown()` |
| __`%el%`__ | `eraseLine()` |
| __`%ee%`__ | `eraseLineToEOL()` |
| __`%es%`__ | `eraseLineToSOL()` |
| __`%cb<num>%`__ | `cursorBack(<num>)` |
| __`%cf<num>%`__ | `cursorForward(<num>)` |
| __`%cu<num>%`__ | `cursorUp(<num>)` |
| __`%cd<num>%`__ | `cursorDown(<num>)` |
| __`%xy<x>,<y>%`__ | `cursorPosition(<x>, <y>)` |
| __`%lf%`__ | `lf()` |